### PR TITLE
Fix 0.0.0 version in wheel metadata (setuptools-scm)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,10 +9,13 @@ source:
   sha256: 124233e9a31a62030a07aafd48c26689561926f4e10417ed3ea46c211218f2b4
 
 build:
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . -vv
   script_env:
     - PYTHON_ISAL_LINK_DYNAMIC=true  # Forces a dynamic link against isa-l in conda-forge
+    # Pin the version so setuptools-scm doesn't resolve the feedstock git tree
+    # in the build sandbox and fall back to 0.0.0 in the wheel metadata.
+    - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
 
 requirements:
   build:
@@ -25,7 +28,7 @@ requirements:
     - python
     - pip
     - setuptools
-    - versioningit >=1.1.0
+    - setuptools-scm >=8
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ test:
   commands:
     - python -c "from isal import igzip"
     - python -c "from isal import isal_zlib; isal_zlib.adler32(b'test')"
+    - python -c "from importlib.metadata import version; assert version('isal') == '{{ version }}'"
 
 about:
   home: https://github.com/pycompression/python-isal


### PR DESCRIPTION
Hey @rhpvorderman 

Just patching a small packaging issue I ran into with a downstream conda package that imports xopen. I don't think it's a functional issue, it just causes `pip check` to fail in environments that have installed python-isal (and python-zlib-ng) through conda.

Reprex:

```sh
$ pixi init && pixi add pip python-isal
$ pixi run pip show isal | grep Version
```

